### PR TITLE
Vscode version

### DIFF
--- a/generators/app/env.js
+++ b/generators/app/env.js
@@ -22,31 +22,6 @@ var vscodePromise = new Promise(function(resolve, reject) {
         }
         resolve(vscodeFallbackVersion);
     });
-    // request.get('https://vscode-update.azurewebsites.net/api/releases/stable', { headers: { "X-API-Version": "2" } }, function(error, response, body) {
-    //     if (!error && response.statusCode === 200) {
-    //         try {
-    //             var tagsAndCommits = JSON.parse(body);
-    //             if (Array.isArray(tagsAndCommits) && tagsAndCommits.length > 0) {
-    //                 var segments = tagsAndCommits[0].version.split('.');
-    //                 if (tagsAndCommits.length > 3) {
-    //                     // Ops Studio is usually a couple of versions behind so
-    //                     // should use the correct version
-    //                     var segments = tagsAndCommits[2].version.split('.');
-    //                 }
-    //                 var segments = tagsAndCommits[0].version.split('.');
-    //                 if (segments.length === 3) {
-    //                     resolve('^' + segments[0] + '.' + segments[1] + '.0');
-    //                     return;
-    //                 }
-    //             }
-    //         } catch (e) {
-    //             console.log('Problem parsing version: ' + body, e);
-    //         }
-    //     } else {
-    //         console.log('Unable to fetch latest vscode version: ' + (error || ('Status code: ' + response.statusCode + ', ' + body)));
-    //     }
-    //     resolve(vscodeFallbackVersion);
-    // });
 });
 
 module.exports.getLatestVSCodeVersion = function() { return vscodePromise; };

--- a/generators/app/env.js
+++ b/generators/app/env.js
@@ -6,22 +6,13 @@ var request = require('request');
 
 var vscodeFallbackVersion = '^1.19.0';
 var vscodePromise = new Promise(function(resolve, reject) {
-    request.get('https://vscode-update.azurewebsites.net/api/releases/stable', { headers: { "X-API-Version": "2" } }, function(error, response, body) {
+    request.get('https://raw.githubusercontent.com/microsoft/azuredatastudio/master/product.json', {}, function(error, response, body) {
         if (!error && response.statusCode === 200) {
             try {
-                var tagsAndCommits = JSON.parse(body);
-                if (Array.isArray(tagsAndCommits) && tagsAndCommits.length > 0) {
-                    var segments = tagsAndCommits[0].version.split('.');
-                    if (tagsAndCommits.length > 3) {
-                        // Ops Studio is usually a couple of versions behind so
-                        // should use the correct version
-                        var segments = tagsAndCommits[2].version.split('.');
-                    }
-                    var segments = tagsAndCommits[0].version.split('.');
-                    if (segments.length === 3) {
-                        resolve('^' + segments[0] + '.' + segments[1] + '.0');
-                        return;
-                    }
+                var currentAzureDataStudio = JSON.parse(body);
+                if (currentAzureDataStudio.vscodeVersion) {
+                    resolve('^'+currentAzureDataStudio.vscodeVersion);
+                    return;
                 }
             } catch (e) {
                 console.log('Problem parsing version: ' + body, e);
@@ -31,6 +22,31 @@ var vscodePromise = new Promise(function(resolve, reject) {
         }
         resolve(vscodeFallbackVersion);
     });
+    // request.get('https://vscode-update.azurewebsites.net/api/releases/stable', { headers: { "X-API-Version": "2" } }, function(error, response, body) {
+    //     if (!error && response.statusCode === 200) {
+    //         try {
+    //             var tagsAndCommits = JSON.parse(body);
+    //             if (Array.isArray(tagsAndCommits) && tagsAndCommits.length > 0) {
+    //                 var segments = tagsAndCommits[0].version.split('.');
+    //                 if (tagsAndCommits.length > 3) {
+    //                     // Ops Studio is usually a couple of versions behind so
+    //                     // should use the correct version
+    //                     var segments = tagsAndCommits[2].version.split('.');
+    //                 }
+    //                 var segments = tagsAndCommits[0].version.split('.');
+    //                 if (segments.length === 3) {
+    //                     resolve('^' + segments[0] + '.' + segments[1] + '.0');
+    //                     return;
+    //                 }
+    //             }
+    //         } catch (e) {
+    //             console.log('Problem parsing version: ' + body, e);
+    //         }
+    //     } else {
+    //         console.log('Unable to fetch latest vscode version: ' + (error || ('Status code: ' + response.statusCode + ', ' + body)));
+    //     }
+    //     resolve(vscodeFallbackVersion);
+    // });
 });
 
 module.exports.getLatestVSCodeVersion = function() { return vscodePromise; };

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -822,6 +822,13 @@ module.exports = class extends Generator {
             this.log('');
         }
 
+        if (this.extensionConfig.type === 'ext-command-ts') {
+            this.log('To include proposed Azure Data Studio APIs in your extension, run the following after opening the directory:');
+            this.log('');
+            this.log(chalk.default.blue('npm run proposedapi'));
+            this.log('');
+        }
+
         this.log('For more information, also visit http://code.visualstudio.com and follow us @code.');
         this.log('\r\n');
     }

--- a/generators/app/templates/ext-command-ts/README.md
+++ b/generators/app/templates/ext-command-ts/README.md
@@ -5,6 +5,12 @@ If you want to build your extension, run:
 npm run compile
 ```
 
+If you want to include proposed Azure Data Studio APIs, run:
+
+```
+npm run proposedapi
+```
+
 # <%= name %> README
 
 This is the README for your extension "<%= name %>". After writing up a brief description, we recommend including the following sections.


### PR DESCRIPTION
adjusts generator to check ADS repository for current VS code version instead of pulling the most recent VS code which is often not supported in ADS yet.

referenced in: https://github.com/microsoft/azuredatastudio/issues/4668