### PR TITLE
Fixes for Jupyter Book & CLI

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -626,7 +626,7 @@ module.exports = class extends Generator {
                         type: 'input',
                         name: 'notebookPath',
                         message: 'Provide the absolute path to the folder containing your notebooks.',
-                        default: path.join(os.homedir(), 'Desktop', 'notebooks')
+                        default: os.homedir()
                     }).then(pathResponse => {
                         generator.extensionConfig.notebookNames = [];
                         generator.extensionConfig.notebookPaths = [];
@@ -688,7 +688,7 @@ module.exports = class extends Generator {
                         type: 'input',
                         name: 'bookLocation',
                         message: 'Provide the absolute path to the folder containing your Jupyter Book:',
-                        default: path.join(os.homedir(), 'Desktop', 'jupyter-book'),
+                        default: os.homedir(),
                         validate: validator.validateFilePath
                     }).then(locationResponse => {
                         let tempPath = path.normalize(locationResponse.bookLocation);
@@ -713,7 +713,7 @@ module.exports = class extends Generator {
                             type: 'input',
                             name: 'notebookPath',
                             message: 'Provide the absolute path to the folders where your notebooks currently exist.',
-                            default: path.join(os.homedir(), 'Desktop', 'notebooks'),
+                            default: os.homedir(),
                             validate: validator.validateFilePath,
                         },
                         {
@@ -748,19 +748,23 @@ module.exports = class extends Generator {
                         },
                         {
                             type: 'input',
-                            name: 'chapterNames',
-                            message: 'List the name(s) of your chapter(s), separated by a comma for each new chapter. (e.g.:\'Placeholder,Placeholder2\')',
-                            validate: validator.validateNonEmpty,
+                            name: 'rawChapterNames',
+                            message: 'List the name(s) of your chapter(s), separated by a comma for each new chapter. (e.g.:\'1 - Chapter 1, 2 - Chapter 2\')',
+                            validate: validator.validateNonEmpty
                         },
                     ]);
-                    let folderNames = []
-                    bookSections.chapterNames = bookSections.chapterNames.split(',');
-                    bookSections.chapterNames.forEach(name => {
-                        let regexSection = name.trim().replace(/[^a-zA-Z0-9]/g, '-');
+                    let folderNames = [];
+                    let chapterNames = [];
+                    bookSections.rawChapterNames = bookSections.rawChapterNames.split(',');
+                    bookSections.rawChapterNames.forEach(name => {
+                        let trimmedStr = name.trim();
+                        chapterNames.push(name.trim())
+                        let regexSection = trimmedStr.replace(/[^a-zA-Z0-9]/g, '-');
                         folderNames.push(regexSection);
                     })
                     Object.assign(generator.extensionConfig, bookSections);
                     generator.extensionConfig.folderNames = folderNames;
+                    generator.extensionConfig.chapterNames = chapterNames;
                 }
             },
 

--- a/generators/app/notebookConverter.js
+++ b/generators/app/notebookConverter.js
@@ -126,7 +126,7 @@ const customizeJupyterBook = (context) => {
             const stats = fs.statSync(dirPath);
             if (stats.isDirectory()) {
                 const chapterFilePath = path.join(presentDirectory[0], context.name, 'content', file);
-                const chapterTitle = context.sectionNames[idx];
+                const chapterTitle = context.chapterNames[idx];
                 tocContent += `- title: ${chapterTitle}\n  url: ${file}/readme\n  not_numbered: true\n  expand_sections: true\n  sections: \n`;
                 tocContent += writeForEachNotebook(file, chapterFilePath);
                 writeToReadme(chapterFilePath, presentDirectory, context.name, file);

--- a/generators/app/notebookConverter.js
+++ b/generators/app/notebookConverter.js
@@ -112,22 +112,12 @@ exports.buildCustomBook = (context) => {
 // Following functions are to perform file input/output to create a custom readme.md
 // for each chapter and a custom toc.yml for the overall book in line with the
 // SQL Server 2019 Jupyter Book in ADS
-const determineExtensionLocation = (context) => {
-    const presentDirectory = __dirname.split('generators');
-    const internalPath = path.join(presentDirectory[0], context.name);
-    const externalPath = path.join(presentDirectory[0], '..', context.name)
-    if (fs.existsSync(internalPath)) {
-        return internalPath;
-    }
-    return externalPath;
-}
-
 const customizeJupyterBook = (context) => {
     let tocContent = "";
     let idx = 0;
-    const extensionLocation = determineExtensionLocation(context)
-    const tocFilePath = path.join(extensionLocation, '_data', 'toc.yml');
-    const bookContentPath = path.join(extensionLocation, 'content');
+
+    const tocFilePath = path.join('.', '_data', 'toc.yml');
+    const bookContentPath = path.join('.', 'content');
     const bookContents = fs.readdirSync(bookContentPath);
 
     bookContents.forEach(file => {
@@ -135,11 +125,11 @@ const customizeJupyterBook = (context) => {
             const dirPath = path.join(bookContentPath, file);
             const stats = fs.statSync(dirPath);
             if (stats.isDirectory()) {
-                const chapterFilePath = path.join(extensionLocation, 'content', file);
+                const chapterFilePath = path.join('.', 'content', file);
                 const chapterTitle = context.chapterNames[idx];
                 tocContent += `- title: ${chapterTitle}\n  url: ${file}/readme\n  not_numbered: true\n  expand_sections: true\n  sections: \n`;
                 tocContent += writeForEachNotebook(file, chapterFilePath);
-                writeToReadme(chapterFilePath, extensionLocation, file);
+                writeToReadme(chapterFilePath, file);
                 idx += 1;
             } else {
                 tocContent += writeSingleNotebook(bookContentPath, file);
@@ -184,8 +174,8 @@ const getSlicedFilename = (fileName) => {
     }
 }
 
-const writeToReadme = (contentFilePath, extensionLocation, file) => {
-    const readmeFilePath = path.join(extensionLocation, 'content', file, 'readme.md');
+const writeToReadme = (contentFilePath, file) => {
+    const readmeFilePath = path.join('.', 'content', file, 'readme.md');
 
     let fileContent = "## Notebooks in this Chapter\n";
     const files = fs.readdirSync(contentFilePath);

--- a/generators/app/notebookConverter.js
+++ b/generators/app/notebookConverter.js
@@ -204,14 +204,16 @@ const findTitle = (file, filePath) => {
     const data = fs.readFileSync(filePath, 'UTF-8');
     const lines = data.split(/\r?\n/);
 
-    if (lines[0] === '') {
+    if (lines[0] === '' || lines[6].indexOf("collapsed") > -1) {
         return "Untitled";
     }
     if (path.extname(file) === '.ipynb') {
-        return lines[6].replace(/[^a-zA-Z0-9-]/g, ' ').trim();
+        let regexStr = lines[6].replace(/[:#"',]/g, '');
+        return regexStr.replace(/\\n/g, '').trim();
     } else {
         if (path.extname(file) === '.md') {
-            return lines[0].replace(/[^a-zA-Z0-9-]/g, ' ').trim();
+            let regexStr = lines[0].replace(/[:#"',]/g, '');
+            return regexStr.replace(/\\n/g, '').trim();
         }
     }
 }


### PR DESCRIPTION
- Adjusted variable name in notebookConverter.js to use correct name, fix an undefined error
- Cleaned up regexes for finding the titles of files 
- Added fix for command line usage (creates the extension outside of the generator installation).